### PR TITLE
Coinjoin FP Reduction

### DIFF
--- a/src/graphsenselib/db/asynchronous/services/heuristics_service.py
+++ b/src/graphsenselib/db/asynchronous/services/heuristics_service.py
@@ -36,33 +36,62 @@ class CoinJoinDbCallbacks:
     get_tag_summary: Callable | None = None
 
 
-# Whirlpool pools: (denomination_sat, coordinator_fee_sat)
+# ---------------------------------------------------------------------------
+# Whirlpool
+# ---------------------------------------------------------------------------
 WHIRLPOOL_POOLS = [
     (100_000, 5_000),
     (1_000_000, 50_000),
     (5_000_000, 175_000),
     (50_000_000, 1_750_000),
 ]
+WHIRLPOOL_EPSILON_MIN = 100
+WHIRLPOOL_EPSILON_MAX = 110_000
+WHIRLPOOL_TX0_A_MAX = 70
+WHIRLPOOL_ETA1 = 0.5
+WHIRLPOOL_ETA2 = 3
+WHIRLPOOL_TX0_MAX_FORWARD_CHECKS = 20
+WHIRLPOOL_TX0_CONFIRMED_CONFIDENCE = 90
+
+# ---------------------------------------------------------------------------
+# Wasabi 1.x (ZeroLink / mixing levels)
+# ---------------------------------------------------------------------------
 WASABI_10_DENOM_SAT = 10_000_000  # 0.1 BTC
 WASABI_10_EPSILON_SAT = 500_000  # ±5% tolerance
 WASABI_10_A_MAX = 7  # max inputs per participant
-
 WASABI_11_A_MAX = 7  # same as 1.0
+WASABI_1X_MIN_INPUTS = 10
+WASABI_1X_MIN_PARTICIPANTS = 3
+WASABI_1X_SMALL_ROUND_GATE = 20
+WASABI_1X_MAX_SPLIT_RESIDUAL = 0.0001
+WASABI_1X_MAX_TOP_INPUT_SHARE = 0.1
 
+# ---------------------------------------------------------------------------
+# Wasabi 2.0 (WabiSabi)
+# ---------------------------------------------------------------------------
 WASABI_20_A_MAX = 10  # max inputs per participant
 WASABI_20_MIN_INPUTS = 20  # minimum total inputs (lowered post-May 2024)
 WASABI_20_V_MIN = 5_000  # minimum output value (sat)
 WASABI_20_MIN_DENOM_FREQ = 2  # minimum frequency for a value to be a denomination
 WASABI_20_MAX_TOP_INPUT_SHARE = 0.1  # reject if one address owns >10% of inputs
 
-WHIRLPOOL_EPSILON_MIN = 100
-WHIRLPOOL_EPSILON_MAX = 110_000
-WHIRLPOOL_TX0_A_MAX = 70
-WHIRLPOOL_ETA1 = 0.5
-WHIRLPOOL_ETA2 = 3
+# ---------------------------------------------------------------------------
+# Stonewall (Samourai) — used as a veto signal, not a positive detector
+# ---------------------------------------------------------------------------
+STONEWALL_V_MIN = 5_000  # outputs at or below this are dust — ignored as denomination
 
-WHIRLPOOL_TX0_MAX_FORWARD_CHECKS = 20
-WHIRLPOOL_TX0_CONFIRMED_CONFIDENCE = 90
+# ---------------------------------------------------------------------------
+# JoinMarket
+# ---------------------------------------------------------------------------
+JOINMARKET_MIN_PARTICIPANTS = 3
+JOINMARKET_DUST_THRESHOLD = (
+    2730  # outputs at or below are excluded as denomination candidates
+)
+JOINMARKET_CONFIDENCE = 49
+# Large-round structural gates — activate when a tx has at least this many inputs.
+JOINMARKET_LARGE_ROUND_THRESHOLD = 50
+JOINMARKET_MAX_INPUTS_PER_PARTICIPANT = 20
+JOINMARKET_MIN_OUTPUTS_PER_PARTICIPANT = 1.7
 
 
 async def _prefetch_addresses(tx, currency, get_address) -> dict[str, dict]:
@@ -358,6 +387,47 @@ def _build_coinjoin_consensus(coinjoin: CoinJoinHeuristics) -> CoinJoinConsensus
     return CoinJoinConsensus(detected=True, confidence=confidence, sources=sources)
 
 
+def _is_stonewall(tx) -> bool:
+    """Does this tx look like a Samourai Stonewall?
+
+    Stonewall's on-chain shape is always:
+
+    3 or 4 real outputs, exactly two of them equal, the rest change.
+
+    (3 outputs = "simplified stonewall", 4 = classic.)
+    We use the match as a veto signal for those other detectors purely to cut their
+    FP rate, not as a positive claim about what the tx is.
+    """
+    if tx.get("coinbase"):
+        return False
+    inputs = [i for i in tx.get("inputs") or [] if i is not None and i.address]
+    outputs = [o for o in tx.get("outputs") or [] if o is not None and o.address]
+
+    # 3 or 4 outputs (after OP_RETURN is filtered out), ≥2 inputs, all output scripts distinct
+    if len(outputs) not in (3, 4) or len(inputs) < 2:
+        return False
+    if len({o.address[0] for o in outputs}) != len(outputs):
+        return False
+
+    # exactly one value appears exactly twice — that's the pseudo-mix denomination
+    freq = Counter(o.value for o in outputs)
+    denoms = [v for v, c in freq.items() if c == 2]
+    if len(denoms) != 1:
+        return False
+    d = denoms[0]
+    if d < STONEWALL_V_MIN:
+        return False
+
+    # for 4-output Stonewall the two change outputs must differ from each other
+    # (three equal values + one other isn't a Stonewall — that's a different shape)
+    if len(outputs) == 4:
+        non_denom = [o.value for o in outputs if o.value != d]
+        if non_denom[0] == non_denom[1]:
+            return False
+
+    return True
+
+
 def _wasabi_10_heuristic(tx) -> WasabiHeuristic | None:
     """
     Structural check for Wasabi 1.0 (ZeroLink) CoinJoin transactions.
@@ -369,6 +439,16 @@ def _wasabi_10_heuristic(tx) -> WasabiHeuristic | None:
 
     inputs = [i for i in tx.get("inputs") or [] if i is not None and i.address]
     outputs = [o for o in tx.get("outputs") or [] if o is not None and o.address]
+
+    if len(inputs) < WASABI_1X_MIN_INPUTS:
+        return None
+
+    in_script_counts = Counter(i.address[0] for i in inputs)
+    if (
+        in_script_counts.most_common(1)[0][1] / len(inputs)
+        > WASABI_1X_MAX_TOP_INPUT_SHARE
+    ):
+        return None
 
     # find candidate denomination: most frequent output value within the window
     freq = Counter(
@@ -383,6 +463,9 @@ def _wasabi_10_heuristic(tx) -> WasabiHeuristic | None:
 
     # 1. denomination window (explicit guard)
     if not (abs(d - WASABI_10_DENOM_SAT) <= WASABI_10_EPSILON_SAT):
+        return None
+
+    if n < WASABI_1X_MIN_PARTICIPANTS:
         return None
 
     n_scripts_in = len({i.address[0] for i in inputs})
@@ -400,6 +483,18 @@ def _wasabi_10_heuristic(tx) -> WasabiHeuristic | None:
     if n_scripts_out != len(outputs):
         return None
 
+    if len(inputs) < WASABI_1X_SMALL_ROUND_GATE:
+        tot_out = sum(o.value for o in outputs)
+        most_freq = Counter(o.value for o in outputs).most_common(1)[0][0]
+        if tot_out and most_freq:
+            N_hat = round(tot_out / most_freq)
+            if (
+                N_hat > 0
+                and abs(tot_out - N_hat * most_freq) / tot_out
+                <= WASABI_1X_MAX_SPLIT_RESIDUAL
+            ):
+                return None
+
     return WasabiHeuristic(
         detected=True,
         confidence=70,
@@ -409,23 +504,13 @@ def _wasabi_10_heuristic(tx) -> WasabiHeuristic | None:
     )
 
 
-JOINMARKET_MIN_PARTICIPANTS = 2
-JOINMARKET_DUST_THRESHOLD = (
-    2730  # outputs at or below this value excluded as denomination candidates
-)
-JOINMARKET_LOW_CONFIDENCE = 20  # confidence when only 2 equal-value outputs are found
-JOINMARKET_CONFIDENCE = 49  # confidence when 3+ equal-value outputs are found
-
-
 def _joinmarket_heuristic(tx) -> JoinMarketHeuristic | None:
     """
     Structural check for JoinMarket CoinJoin transactions.
     The most frequent output value is the denomination; its count estimates
-    participant count n. JoinMarket is a superset — Wasabi 1.x and Whirlpool
-    CoinJoin txs also satisfy these conditions.
-
-    n=2 (exactly 2 equal-value outputs) is detected with low confidence (20)
-    since equal output values can occur by coincidence. n>=3 uses confidence 49.
+    participant count n. Requires ≥3 participants and
+    at least one non-denomination output (change), which real JM rounds always
+    have — one change output per participant.
     """
     if tx.get("coinbase"):
         return None
@@ -450,7 +535,7 @@ def _joinmarket_heuristic(tx) -> JoinMarketHeuristic | None:
     if not (n >= len(outputs) / 2):
         return None
 
-    # 2. at least 2 participants, each with distinct input
+    # 2. JoinMarket requires ≥3 participants
     if not (JOINMARKET_MIN_PARTICIPANTS <= n <= n_scripts_in):
         return None
 
@@ -458,11 +543,22 @@ def _joinmarket_heuristic(tx) -> JoinMarketHeuristic | None:
     if n_scripts_out != len(outputs):
         return None
 
-    confidence = JOINMARKET_CONFIDENCE if n >= 3 else JOINMARKET_LOW_CONFIDENCE
+    # 4. at least one output must NOT be a denomination
+    if not any(o.value != d for o in outputs):
+        return None
+
+    # 5. for large-input rounds, demand JM-like structure: no extreme input
+    # fan-in (real makers bring 1-3 inputs), and enough outputs per participant
+    # (≈2: denom + change). Exchange batch payouts violate both.
+    if len(inputs) >= JOINMARKET_LARGE_ROUND_THRESHOLD:
+        if len(inputs) / n > JOINMARKET_MAX_INPUTS_PER_PARTICIPANT:
+            return None
+        if len(outputs) / n < JOINMARKET_MIN_OUTPUTS_PER_PARTICIPANT:
+            return None
 
     return JoinMarketHeuristic(
         detected=True,
-        confidence=confidence,
+        confidence=JOINMARKET_CONFIDENCE,
         n_participants=n,
         pool_denomination=d,
     )
@@ -483,6 +579,16 @@ def _wasabi_11_heuristic(tx) -> WasabiHeuristic | None:
     outputs = [o for o in tx.get("outputs") or [] if o is not None and o.address]
 
     if not outputs or not inputs:
+        return None
+
+    if len(inputs) < WASABI_1X_MIN_INPUTS:
+        return None
+
+    in_script_counts = Counter(i.address[0] for i in inputs)
+    if (
+        in_script_counts.most_common(1)[0][1] / len(inputs)
+        > WASABI_1X_MAX_TOP_INPUT_SHARE
+    ):
         return None
 
     # base denomination is a protocol constant — no need to infer from level 0 outputs
@@ -515,6 +621,9 @@ def _wasabi_11_heuristic(tx) -> WasabiHeuristic | None:
     # n lower bound: max count at any single level (all must be distinct participants)
     n = max(level_counts.values())
 
+    if n < WASABI_1X_MIN_PARTICIPANTS:
+        return None
+
     # input bounds
     if not (n <= n_scripts_in <= WASABI_11_A_MAX * n):
         return None
@@ -535,6 +644,18 @@ def _wasabi_11_heuristic(tx) -> WasabiHeuristic | None:
     # all output scripts distinct
     if n_scripts_out != len(outputs):
         return None
+
+    if len(inputs) < WASABI_1X_SMALL_ROUND_GATE:
+        tot_out = sum(o.value for o in outputs)
+        most_freq = Counter(o.value for o in outputs).most_common(1)[0][0]
+        if tot_out and most_freq:
+            N_hat = round(tot_out / most_freq)
+            if (
+                N_hat > 0
+                and abs(tot_out - N_hat * most_freq) / tot_out
+                <= WASABI_1X_MAX_SPLIT_RESIDUAL
+            ):
+                return None
 
     # confidence scoring: 0-100
     # n_tightness: how well participant count is bounded (1.0 = exact, single-level case)
@@ -628,10 +749,6 @@ def _wasabi_20_heuristic(tx) -> WasabiHeuristic | None:
     # distinct denomination tiers are present in practice. A single repeated
     # value (JoinMarket-style or N-way payout) doesn't qualify.
     if len(denom_set) < 3:
-        return None
-
-    # 6. enough denomination outputs relative to inputs
-    if not (n_denom_outputs >= len(inputs) / WASABI_20_A_MAX):
         return None
 
     # participant estimate: number of distinct input scripts / a_max as lower bound
@@ -1008,6 +1125,24 @@ async def calculate_heuristics(
             if coinjoin is None:
                 coinjoin = CoinJoinHeuristics()
             coinjoin.joinmarket = joinmarket_result
+
+    # Stonewall veto (FP reduction): if the tx has a Stonewall / simplified-Stonewall
+    # shape, our other CoinJoin detectors firing on it are nearly always wrong
+    if coinjoin is not None and _is_stonewall(tx):
+        coinjoin.wasabi = None
+        coinjoin.joinmarket = None
+        coinjoin.whirlpool_coinjoin = None
+        coinjoin.whirlpool_tx0 = None
+        if all(
+            v is None
+            for v in (
+                coinjoin.wasabi,
+                coinjoin.joinmarket,
+                coinjoin.whirlpool_coinjoin,
+                coinjoin.whirlpool_tx0,
+            )
+        ):
+            coinjoin = None
 
     # Exchange false-positive suppression: if JoinMarket or Wasabi 1.x fired, check
     # whether any input comes from a known exchange. If yes, remove those results —

--- a/src/graphsenselib/db/asynchronous/services/heuristics_service.py
+++ b/src/graphsenselib/db/asynchronous/services/heuristics_service.py
@@ -53,6 +53,7 @@ WASABI_20_A_MAX = 10  # max inputs per participant
 WASABI_20_MIN_INPUTS = 20  # minimum total inputs (lowered post-May 2024)
 WASABI_20_V_MIN = 5_000  # minimum output value (sat)
 WASABI_20_MIN_DENOM_FREQ = 2  # minimum frequency for a value to be a denomination
+WASABI_20_MAX_TOP_INPUT_SHARE = 0.1  # reject if one address owns >10% of inputs
 
 WHIRLPOOL_EPSILON_MIN = 100
 WHIRLPOOL_EPSILON_MAX = 110_000
@@ -584,6 +585,14 @@ def _wasabi_20_heuristic(tx) -> WasabiHeuristic | None:
     if len(inputs) < WASABI_20_MIN_INPUTS:
         return None
 
+    # 1b. reject concentration sweeps: no single address may own >X% of inputs.
+    in_script_counts = Counter(i.address[0] for i in inputs)
+    if (
+        in_script_counts.most_common(1)[0][1] / len(inputs)
+        > WASABI_20_MAX_TOP_INPUT_SHARE
+    ):
+        return None
+
     # 2. no tiny outputs
     if any(o.value < WASABI_20_V_MIN for o in outputs):
         return None
@@ -604,6 +613,21 @@ def _wasabi_20_heuristic(tx) -> WasabiHeuristic | None:
 
     # 5. at least half of outputs (minus coordinator fee) are denomination outputs
     if not (n_denom_outputs >= (len(outputs) - 1) / 2):
+        return None
+
+    # 5b. precision/recall tradeoff filter: require at least one non-denomination
+    # output. Most WabiSabi rounds have a coordinator fee and/or change output,
+    # but all-remix rounds with clean decompositions legitimately have neither
+    # (coordinator fee is 0% on remixes). Rejecting these loses a small number
+    # of true positives in exchange for eliminating many deterministic N-way
+    # split batch-payout false positives.
+    if n_denom_outputs == len(outputs):
+        return None
+
+    # 5c. real WabiSabi rounds use a power-of-2 denomination schedule, so ≥3
+    # distinct denomination tiers are present in practice. A single repeated
+    # value (JoinMarket-style or N-way payout) doesn't qualify.
+    if len(denom_set) < 3:
         return None
 
     # 6. enough denomination outputs relative to inputs

--- a/tests/db/test_heuristics.py
+++ b/tests/db/test_heuristics.py
@@ -8,6 +8,7 @@ OP_RETURN outputs are objects with an empty address list and zero value.
 from types import SimpleNamespace
 
 from graphsenselib.db.asynchronous.services.heuristics_service import (
+    _is_stonewall,
     _joinmarket_heuristic,
     _wasabi_10_heuristic,
     _wasabi_11_heuristic,
@@ -15,6 +16,7 @@ from graphsenselib.db.asynchronous.services.heuristics_service import (
     _whirlpool_tx0_heuristic,
     _whirlpool_coinjoin_heuristic,
     JOINMARKET_DUST_THRESHOLD,
+    STONEWALL_V_MIN,
     WASABI_10_DENOM_SAT,
     WASABI_10_EPSILON_SAT,
     WASABI_10_A_MAX,
@@ -536,7 +538,7 @@ class TestWasabi10HappyPath:
     D = WASABI_10_DENOM_SAT  # 10_000_000 sat
     FEE = 50_000  # coordinator fee (arbitrary unique value)
 
-    def _make_wasabi10(self, n, n_change=None, fee=None, inputs_per_participant=1):
+    def _make_wasabi10(self, n, n_change=None, fee=None, inputs_per_participant=4):
         """Build a valid Wasabi 1.0 tx with n participants."""
         if n_change is None:
             n_change = n  # all participants have change by default
@@ -591,7 +593,7 @@ class TestWasabi10HappyPath:
             + [make_output(d // 3 + i * 1001, f"change_{i}") for i in range(5)]
             + [make_output(self.FEE, "coordinator")]
         )
-        inputs = [make_input(d * 2, f"inp_{i}") for i in range(5)]
+        inputs = [make_input(d * 2, f"inp_{i}_{j}") for i in range(5) for j in range(2)]
         result = _wasabi_10_heuristic(make_tx(inputs, outputs))
         assert result is not None
         assert result.denominations == [d]
@@ -604,7 +606,7 @@ class TestWasabi10HappyPath:
             + [make_output(d // 3 + i * 1001, f"change_{i}") for i in range(5)]
             + [make_output(self.FEE, "coordinator")]
         )
-        inputs = [make_input(d * 2, f"inp_{i}") for i in range(5)]
+        inputs = [make_input(d * 2, f"inp_{i}_{j}") for i in range(5) for j in range(2)]
         result = _wasabi_10_heuristic(make_tx(inputs, outputs))
         assert result is not None
         assert result.denominations == [d]
@@ -739,10 +741,18 @@ class TestWasabi11HappyPath:
     D = WASABI_10_DENOM_SAT  # 10_000_000 sat base denomination
     FEE = 50_000
 
-    def _make_wasabi11(self, level_counts: dict[int, int], n_change=None, fee=None):
+    def _make_wasabi11(
+        self,
+        level_counts: dict[int, int],
+        n_change=None,
+        fee=None,
+        inputs_per_participant: int = 4,
+    ):
         """
         Build a valid Wasabi 1.1 tx.
         level_counts: {level_index: n_outputs_at_that_level}
+        inputs_per_participant defaults to 4 so tests clear the WASABI_1X_MIN_INPUTS
+        floor even with small participant counts.
         """
         fee = fee or self.FEE
         outputs = []
@@ -760,7 +770,11 @@ class TestWasabi11HappyPath:
             outputs.append(make_output(self.D // 3 + i * 1001, f"change_{i}"))
 
         outputs.append(make_output(fee, "coordinator"))
-        inputs = [make_input(self.D * 4, f"inp_{i}") for i in range(n_participants)]
+        inputs = [
+            make_input(self.D * 4, f"inp_{i}_{j}")
+            for i in range(n_participants)
+            for j in range(inputs_per_participant)
+        ]
         return make_tx(inputs, outputs)
 
     def test_two_levels(self):
@@ -816,7 +830,9 @@ class TestWasabi11HappyPath:
 
     def test_confidence_high_with_one_input_per_participant(self):
         """Best case: one input per participant — confidence must be 100."""
-        result = _wasabi_11_heuristic(self._make_wasabi11({0: 4, 1: 4}))
+        result = _wasabi_11_heuristic(
+            self._make_wasabi11({0: 10, 1: 10}, inputs_per_participant=1)
+        )
         assert result.confidence == 100
 
     def test_no_change_outputs(self):
@@ -941,17 +957,15 @@ class TestJoinMarketHappyPath:
         inputs = [make_input(d * 2, f"inp_{i}") for i in range(n)]
         return make_tx(inputs, outputs)
 
-    def test_minimal_valid(self):
-        """Minimum 2 participants — detected with low confidence."""
+    def test_two_participants_rejected(self):
+        """2 participants — rejected. Real JoinMarket has 1 taker + ≥2 makers
+        (≥3 total). 2-equal-output patterns are too ambiguous (2-way splits,
+        stonewall post-mix, simple batch pairs)."""
         result = _joinmarket_heuristic(self._make_joinmarket(2))
-        assert result is not None
-        assert result.detected is True
-        assert result.n_participants == 2
-        assert result.pool_denomination == self.D
-        assert result.confidence == 20
+        assert result is None
 
     def test_three_participants(self):
-        """3 participants — detected with normal confidence."""
+        """3 participants — minimum valid round."""
         result = _joinmarket_heuristic(self._make_joinmarket(3))
         assert result is not None
         assert result.detected is True
@@ -965,11 +979,12 @@ class TestJoinMarketHappyPath:
         assert result is not None
         assert result.n_participants == 8
 
-    def test_no_change_outputs(self):
-        """All participants without change — still valid."""
+    def test_no_change_outputs_rejected(self):
+        """All outputs equal the denomination — deterministic N-way split, not
+        a CoinJoin. Real JM rounds always have change outputs (one per
+        participant, from leftover inputs after denomination + fee)."""
         result = _joinmarket_heuristic(self._make_joinmarket(5, n_change=0))
-        assert result is not None
-        assert result.n_participants == 5
+        assert result is None
 
     def test_arbitrary_denomination(self):
         """JoinMarket has no fixed denomination — any value should work."""
@@ -992,9 +1007,9 @@ class TestJoinMarketHappyPath:
         assert _joinmarket_heuristic(make_tx(inputs, outputs)) is None
 
     def test_confidence_below_wasabi(self):
-        """JoinMarket confidence must be lower than Wasabi minimum (50)."""
+        """JoinMarket confidence must be lower than Wasabi minimum (60)."""
         result = _joinmarket_heuristic(self._make_joinmarket(5))
-        assert result.confidence < 50
+        assert result.confidence < 60
 
     def test_op_return_ignored(self):
         """OP_RETURN in outputs must not affect detection."""
@@ -1024,10 +1039,20 @@ class TestJoinMarketRejection:
     def test_coinbase_rejected(self):
         assert _joinmarket_heuristic(make_tx([], [], coinbase=True)) is None
 
-    def test_fewer_than_2_participants_rejected(self):
-        """n=1 fails the minimum participant check."""
-        result = _joinmarket_heuristic(self._make_joinmarket(1))
-        assert result is None
+    def test_fewer_than_3_participants_rejected(self):
+        """n=1 and n=2 fail the minimum participant check (Patch D — JM
+        requires 1 taker + ≥2 makers = 3 total)."""
+        assert _joinmarket_heuristic(self._make_joinmarket(1)) is None
+        assert _joinmarket_heuristic(self._make_joinmarket(2)) is None
+
+    def test_all_outputs_are_denomination_rejected(self):
+        """Patch E — every output equals the denomination, so there's no
+        change output. This is a deterministic N-way split (batch payout),
+        not a JoinMarket round."""
+        d = 50_000_000
+        outputs = [make_output(d, f"recipient_{i}") for i in range(5)]
+        inputs = [make_input(d * 2, f"inp_{i}") for i in range(5)]
+        assert _joinmarket_heuristic(make_tx(inputs, outputs)) is None
 
     def test_postmix_not_majority_rejected(self):
         """n < |outputs| / 2 — too many non-postmix outputs."""
@@ -1243,16 +1268,15 @@ class TestWasabi20Rejection:
 class TestFalsePositiveScenarios:
     """Transactions that superficially resemble CoinJoin but are not."""
 
-    def test_batch_payout_detected_as_joinmarket(self):
+    def test_batch_payout_rejected_as_joinmarket(self):
         """An exchange paying 10 users exactly 0.5 BTC each with 10 distinct
-        hot-wallet UTXOs as inputs. Structurally indistinguishable from
-        JoinMarket — this is a known limitation. We document that it passes."""
+        hot-wallet UTXOs as inputs. Previously a known FP (structurally equal
+        outputs, no change). Now rejected by the `has_non_denom_output` guard
+        (Patch E) since every output equals the denomination."""
         d = 50_000_000  # 0.5 BTC
         outputs = [make_output(d, f"user_{i}") for i in range(10)]
         inputs = [make_input(d * 2, f"hotwallet_utxo_{i}") for i in range(10)]
-        result = _joinmarket_heuristic(make_tx(inputs, outputs))
-        # known false positive — structurally identical to JoinMarket
-        assert result is not None
+        assert _joinmarket_heuristic(make_tx(inputs, outputs)) is None
 
     def test_batch_payout_with_change_not_joinmarket(self):
         """Same batch payout but with change outputs — now n < |outputs|/2
@@ -1318,3 +1342,181 @@ class TestFalsePositiveScenarios:
         )
         inputs = [make_input(d * 10, f"inp_{i}") for i in range(20)]
         assert _wasabi_11_heuristic(make_tx(inputs, outputs)) is None
+
+
+# ---------------------------------------------------------------------------
+# Stonewall — happy path (match)
+# ---------------------------------------------------------------------------
+
+
+class TestStonewallHappyPath:
+    """Transactions that match the Samourai Stonewall / simplified-Stonewall
+    on-chain shape. `_is_stonewall` is used as a veto against other CoinJoin
+    detectors — this only asserts the shape match itself."""
+
+    D = 1_000_000  # pseudo-mix denomination (≥ STONEWALL_V_MIN)
+
+    def test_simplified_stonewall_3_outputs(self):
+        """3 outputs = [denom, denom, change], 5 inputs."""
+        outputs = [
+            make_output(self.D, "denom_1"),
+            make_output(self.D, "denom_2"),
+            make_output(423_117, "change"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(5)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is True
+
+    def test_classic_stonewall_4_outputs(self):
+        """4 outputs = [denom, denom, change1, change2] with change1 ≠ change2."""
+        outputs = [
+            make_output(self.D, "denom_1"),
+            make_output(self.D, "denom_2"),
+            make_output(423_117, "change_1"),
+            make_output(517_903, "change_2"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(5)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is True
+
+    def test_large_input_stonewall(self):
+        """50+ inputs (wallet consolidation case), 4 outputs in Stonewall shape."""
+        outputs = [
+            make_output(self.D, "denom_1"),
+            make_output(self.D, "denom_2"),
+            make_output(111_111, "change_1"),
+            make_output(222_222, "change_2"),
+        ]
+        inputs = [make_input(50_000, f"inp_{i}") for i in range(55)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is True
+
+    def test_denomination_at_minimum(self):
+        """Denom = exactly STONEWALL_V_MIN (5000 sat). The check is strict
+        less-than (`d < STONEWALL_V_MIN`), so exactly the threshold passes."""
+        d = STONEWALL_V_MIN  # 5_000
+        outputs = [
+            make_output(d, "denom_1"),
+            make_output(d, "denom_2"),
+            make_output(1_234, "change"),
+        ]
+        inputs = [make_input(d, f"inp_{i}") for i in range(3)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is True
+
+    def test_op_return_ignored(self):
+        """OP_RETURN outputs are filtered out before checking output count/shape."""
+        outputs = [
+            make_output(self.D, "denom_1"),
+            make_output(self.D, "denom_2"),
+            make_output(423_117, "change"),
+            make_op_return(),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(5)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is True
+
+
+# ---------------------------------------------------------------------------
+# Stonewall — rejection cases
+# ---------------------------------------------------------------------------
+
+
+class TestStonewallRejection:
+    """Transactions that do NOT match the Stonewall shape."""
+
+    D = 1_000_000
+
+    def test_coinbase_rejected(self):
+        assert _is_stonewall(make_tx([], [], coinbase=True)) is False
+
+    def test_fewer_than_3_outputs(self):
+        """2-output tx can't be Stonewall."""
+        outputs = [
+            make_output(self.D, "a"),
+            make_output(self.D, "b"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(3)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False
+
+    def test_5_outputs_rejected(self):
+        """5-output tx — beyond Stonewall's 3-or-4 shape, even with 2 equals."""
+        outputs = [
+            make_output(self.D, "denom_1"),
+            make_output(self.D, "denom_2"),
+            make_output(100_000, "change_1"),
+            make_output(200_000, "change_2"),
+            make_output(300_000, "change_3"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(5)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False
+
+    def test_single_input_rejected(self):
+        """1-input tx — Stonewall requires ≥2 inputs (two parties)."""
+        outputs = [
+            make_output(self.D, "denom_1"),
+            make_output(self.D, "denom_2"),
+            make_output(423_117, "change"),
+        ]
+        inputs = [make_input(self.D * 3, "sole_input")]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False
+
+    def test_no_equal_pair(self):
+        """3 distinct output values — no pair to be the denomination."""
+        outputs = [
+            make_output(1_000_000, "a"),
+            make_output(2_000_000, "b"),
+            make_output(3_000_000, "c"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(3)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False
+
+    def test_three_equal_outputs(self):
+        """3 outputs all equal — freq[value]==3, not 2, so no denom is picked."""
+        outputs = [
+            make_output(self.D, "a"),
+            make_output(self.D, "b"),
+            make_output(self.D, "c"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(3)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False
+
+    def test_two_pairs_rejected(self):
+        """4 outputs with shape [a,a,b,b] — freq has two values at count 2, so
+        `len(denoms) != 1` rejects before the non-denom-equality check."""
+        outputs = [
+            make_output(self.D, "a_1"),
+            make_output(self.D, "a_2"),
+            make_output(2 * self.D, "b_1"),
+            make_output(2 * self.D, "b_2"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(4)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False
+
+    def test_four_output_equal_non_denoms_rejected(self):
+        """4 outputs [denom, denom, change, change] with change1 == change2 —
+        rejected by the 4-output branch requiring the non-denom pair to differ."""
+        outputs = [
+            make_output(self.D, "denom_1"),
+            make_output(self.D, "denom_2"),
+            make_output(100_000, "change_1"),
+            make_output(100_000, "change_2"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(4)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False
+
+    def test_dust_denomination_rejected(self):
+        """Denom = 4_999 (just under STONEWALL_V_MIN) — rejected as dust."""
+        d = STONEWALL_V_MIN - 1  # 4_999
+        outputs = [
+            make_output(d, "denom_1"),
+            make_output(d, "denom_2"),
+            make_output(1_234, "change"),
+        ]
+        inputs = [make_input(10_000, f"inp_{i}") for i in range(3)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False
+
+    def test_duplicate_output_script_rejected(self):
+        """Two outputs at the same address — not all scripts distinct."""
+        outputs = [
+            make_output(self.D, "same_addr"),
+            make_output(self.D, "same_addr"),  # duplicate script
+            make_output(423_117, "change"),
+        ]
+        inputs = [make_input(self.D, f"inp_{i}") for i in range(3)]
+        assert _is_stonewall(make_tx(inputs, outputs)) is False

--- a/tests/db/test_heuristics.py
+++ b/tests/db/test_heuristics.py
@@ -1096,15 +1096,16 @@ class TestWasabi20HappyPath:
         return make_tx(inputs, outputs)
 
     def test_minimal_valid(self):
-        """20 inputs, single denomination with enough outputs."""
+        """20 inputs, three denomination tiers with enough outputs."""
         # 30 denom outputs + 10 change + 1 coordinator = 41 outputs
         # denom majority: 30 >= (41-1)/2 = 20 ✓
         # denom vs inputs: 30 >= 20/10 = 2 ✓
-        result = _wasabi_20_heuristic(self._make_wasabi20({200_000: 30}, n_inputs=20))
+        denoms = {100_000: 10, 200_000: 10, 400_000: 10}
+        result = _wasabi_20_heuristic(self._make_wasabi20(denoms, n_inputs=20))
         assert result is not None
         assert result.detected is True
         assert result.version == "2.0"
-        assert result.denominations == [200_000]
+        assert set(result.denominations) == {100_000, 200_000, 400_000}
 
     def test_multiple_denominations(self):
         """Multiple denomination values in set D."""
@@ -1116,7 +1117,7 @@ class TestWasabi20HappyPath:
 
     def test_large_round(self):
         """100 inputs, typical large WabiSabi round."""
-        denoms = {100_000: 40, 500_000: 20}
+        denoms = {100_000: 30, 200_000: 20, 500_000: 10}
         result = _wasabi_20_heuristic(
             self._make_wasabi20(denoms, n_inputs=100, n_change=15)
         )
@@ -1125,26 +1126,29 @@ class TestWasabi20HappyPath:
 
     def test_exactly_20_inputs(self):
         """Boundary: exactly 20 inputs should pass."""
-        result = _wasabi_20_heuristic(self._make_wasabi20({300_000: 30}, n_inputs=20))
+        denoms = {100_000: 10, 200_000: 10, 400_000: 10}
+        result = _wasabi_20_heuristic(self._make_wasabi20(denoms, n_inputs=20))
         assert result is not None
 
     def test_no_change_outputs(self):
-        """All outputs are denominations — no change."""
+        """All outputs are denominations — no change (coordinator is the non-denom)."""
+        denoms = {150_000: 15, 250_000: 15, 400_000: 10}
         result = _wasabi_20_heuristic(
-            self._make_wasabi20({200_000: 40}, n_change=0, n_inputs=50)
+            self._make_wasabi20(denoms, n_change=0, n_inputs=50)
         )
         assert result is not None
 
     def test_op_return_ignored(self):
         """OP_RETURN outputs should be filtered out, not cause crashes."""
-        tx = self._make_wasabi20({200_000: 30}, n_inputs=50)
+        denoms = {100_000: 10, 200_000: 10, 400_000: 10}
+        tx = self._make_wasabi20(denoms, n_inputs=50)
         tx["outputs"].append(make_op_return())
         result = _wasabi_20_heuristic(tx)
         assert result is not None
 
     def test_denominations_not_near_01_btc(self):
         """Wasabi 2.0 has no fixed denomination — values far from 0.1 BTC should work."""
-        denoms = {50_000: 15, 75_000: 15}
+        denoms = {50_000: 10, 75_000: 10, 100_000: 10}
         result = _wasabi_20_heuristic(
             self._make_wasabi20(denoms, n_change=5, n_inputs=55)
         )
@@ -1153,7 +1157,8 @@ class TestWasabi20HappyPath:
 
     def test_confidence_is_set(self):
         """Confidence should be a reasonable value."""
-        result = _wasabi_20_heuristic(self._make_wasabi20({200_000: 30}, n_inputs=50))
+        denoms = {100_000: 10, 200_000: 10, 400_000: 10}
+        result = _wasabi_20_heuristic(self._make_wasabi20(denoms, n_inputs=50))
         assert result.confidence > 0
         assert result.confidence <= 100
 


### PR DESCRIPTION
# CoinJoin heuristic FP reduction (Wasabi 2.0 + JoinMarket + Wasabi 1.x)

## TL;DR

Ten structural patches across three heuristics —
`_wasabi_20_heuristic` (A/B/C), `_joinmarket_heuristic` (D/E/F), and
the shared Wasabi 1.x path `_wasabi_10_heuristic` / `_wasabi_11_heuristic`
(G/H/I/J) — raise protocol-label precision and reduce the hard-FP rate
(amie says "not a CoinJoin") across all three detectors.

| protocol | evaluated | correct (before → after) | hard FP (before → after) | TP cost |
|---|---:|---|---|---|
| Wasabi 2.0 | 1,520 | 83.6% → **99.8%** | 1.1% → **0.0%** | 0.47% (6 / 1,270 TPs) |
| JoinMarket | 2,008 | 61.9% → **86.8%** | 9.4% → **3.7%** | 0.80% (10 / 1,242 TPs) |
| Wasabi 1.x | 5,287 | — | 10.3% → **1.6%** | plausible TP 116 → 102 (14 lost) |

Ground truth: [`am-i-exposed`](https://github.com/Copexit/am-i-exposed)
CLI labels (32 chain-analysis heuristics + entity detection) on a snapshot
dataset of 262,892 txs, 5,287 of which were AMIE-evaluated.

---

## Wasabi 2.0 — `_wasabi_20_heuristic`

### Patch A — input-concentration guard

We reject if any single input address
owns more than 10% of the round's inputs.

```python
WASABI_20_MAX_TOP_INPUT_SHARE = 0.1
if in_script_counts.most_common(1)[0][1] / len(inputs) > WASABI_20_MAX_TOP_INPUT_SHARE:
    return None
```

<details>
<summary>ROC sweep and threshold selection</summary>

AUC 0.810 (positive = amie `wabisabi-coinjoin`, negative = `simple-payment`);
AUC 0.876 (positive = any CoinJoin). We chose `t = 0.10` — removes 23 of
218 negatives while giving up ≈0.3% TPR (6 of 1,270 real Wasabi rounds
rejected).

<img width="1200" height="1200" alt="image" src="https://github.com/user-attachments/assets/2d0c6fd7-62c3-4587-beba-a1b6edac1800" />

</details>

### Patch B — require a non-denomination output

Real WabiSabi rounds always have a coordinator fee and/or change output.
A tx where every output sits at a denomination value is a deterministic
N-way split (batch payout), not a CoinJoin.

```python
if n_denom_outputs == len(outputs):
    return None
```

<details>
<summary>Example case + tradeoff note</summary>

`898f0641a260a0a23827ab6868f5a15b860f88b35c2df2df6a11ca90a19ba9c2` — 33
inputs × 4 outputs, all four at exactly 3,601,916 sat. Pre-patch, the
heuristic emits a confident Wasabi 2.0 detection. AMIE classifies it
`simple-payment`. Post-patch, filter 5b rejects it.

</details>

### Patch C — require ≥3 distinct denomination tiers

WabiSabi uses a power-of-2 denomination schedule, so real rounds produce
≥3 distinct denomination values. A single repeated value is either a
deterministic payout or a JoinMarket-style round.

```python
if len(denom_set) < 3:
    return None
```

<details>
<summary>ROC sweep (post-A+B) — three candidate guards</summary>

Evaluated on 1,520 Wasabi 2.0 detections (P=1,270, N=250):

| guard | AUC | threshold | TPR | FPR | TPs lost |
|---|---:|---:|---:|---:|---:|
| `n_denom_values ≥ t` | **0.999** | **≥ 3** | **1.000** | **0.012** | 0 / 1,071 |
| `n_outputs ≥ t` | 0.962 | — | — | — | — |
| `n_participants ≥ t` | 0.836 | (rejected) | 0.815 | 0.373 | 198 / 1,071 |

<img width="1200" height="1200" alt="wasabi20_guard_roc" src="https://github.com/user-attachments/assets/14cef947-b250-4d30-9cbf-18fcdac03b68" />

`n_denom_values ≥ 3` dominates: removes 246 of 249 residual negatives
while losing **zero** TPs. `n_participants ≥ 3` was considered and
rejected because the ROC showed it would lose 198 real rounds.

</details>

---

## JoinMarket — `_joinmarket_heuristic`

### Patch D — require ≥3 participants

The old heuristic accepted `n = 2` at low confidence, which labelled every 2-way equal-output
payment as JoinMarket.

```python
JOINMARKET_MIN_PARTICIPANTS = 3
```

<details>
<summary>ROC sweep + combined-with-Patch-E curve</summary>

1,171 JM-only detections (P=553, N=618):

| threshold | alone (`n ≥ t`) | combined (D + E) |
|---|---|---|
| `n ≥ 3` | TPR 0.996, FPR 0.375 | **TPR 0.996, FPR 0.217** |
| `n ≥ 4` | TPR 0.908, FPR 0.325 | TPR 0.908, FPR 0.173 |

<img width="1200" height="1200" alt="joinmarket_guard_roc" src="https://github.com/user-attachments/assets/9703e54a-3156-4fb9-bba5-9f06418b1b63" />


</details>

### Patch E — require a non-denomination output

A real JM round produces ≈2 outputs per participant (denomination + change).
If every output equals the denomination, it's a deterministic N-way split.

```python
if not any(o.value != d for o in outputs):
    return None
```

<details>
<summary>Impact on 1,208-sample JM-only eval set</summary>

| metric | before | after D+E |
|---|---:|---:|
| correct | 48.3% | **80.8%** |
| soft mismatch | 41.1% | 13.9% |
| hard FP | 10.6% | 5.3% |

<img width="1200" height="900" alt="joinmarket_precision_before_after" src="https://github.com/user-attachments/assets/44be25a7-e664-422b-a33b-8a555ee0b9fd" />

</details>

### Patch F — large-round structural gates

After D+E, residual hard FPs are exchange batch payouts with extreme
input fan-in (100s of inputs into 3–6 outputs). Gate two structural
checks on rounds with ≥50 inputs:

```python
JOINMARKET_LARGE_ROUND_THRESHOLD = 50
JOINMARKET_MAX_INPUTS_PER_PARTICIPANT = 20
JOINMARKET_MIN_OUTPUTS_PER_PARTICIPANT = 1.7

if len(inputs) >= JOINMARKET_LARGE_ROUND_THRESHOLD:
    if len(inputs) / n > JOINMARKET_MAX_INPUTS_PER_PARTICIPANT:  return None
    if len(outputs) / n < JOINMARKET_MIN_OUTPUTS_PER_PARTICIPANT: return None
```

<details>
<summary>Per-input-bucket precision (before → after F)</summary>

| bucket | n (before → after) | correct (before → after) | hard FP (before → after) |
|---|---|---|---|
| 05–09 | 952 → 542 | 55.4% → **96.9%** | 8.9% → 2.4% |
| 10–19 | 837 → 755 | 82.3% → 91.1% | 7.3% → 3.8% |
| 20–49 | 158 → 113 | 6.3% → 8.8% | 11.4% → 8.8% |
| 50–99 | 30 → 4 | 16.7% → **100.0%** | 50.0% → **0.0%** |
| 100+ | 31 → 5 | 35.5% → **100.0%** | 29.0% → **0.0%** |

The large-input buckets are completely cleaned up.

</details>

---

## Wasabi 1.x — `_wasabi_10_heuristic` / `_wasabi_11_heuristic`

Four patches on the shared 0.1-BTC ZeroLink code path.

### Patch G — minimum input count (`len(inputs) ≥ 10`)

### Patch H — minimum participant count (`n ≥ 3`)

Same rationale as Patch D for JoinMarket — a 2-way equal-output split is
structurally ambiguous.

### Patch I — deterministic N-way split veto

For small rounds (`len(inputs) < 20`), reject if the outputs cleanly
partition into an N-way equal split (residual ≤ 0.0001). TP-free.

<details>
<summary>Why only small rounds</summary>

Real Wasabi 1.x rounds with ≥20 inputs have enough noise in their change
outputs that the split-residual metric is near zero on batch payouts but
non-zero on real rounds. Small rounds don't exhibit this separation, so we
gate the filter by input count.

</details>

### Patch J — input-concentration guard

Same structure as Patch A (single address ≤ 10% of inputs). TP-free.

<details>
<summary>Per-patch hard-FP attribution on Wasabi 1.x</summary>

| step | detections | hard FP | plausible TP |
|---|---:|---:|---:|
| before | 574 | 59 (10.3%) | 116 |
| + G | 530 | 38 (7.2%) | 109 |
| + G+H | 490 | 22 (4.5%) | 102 |
| + G+H+I | 463 | 11 (2.4%) | 102 |
| + G+H+I+J | 449 | **7 (1.6%)** | 102 |

TP cost is concentrated in G/H; I and J are TP-free.

</details>

---

## Future work — confidence mapping instead of binary gates

Several of our signals are continuous, rather than picking one threshold, we could fold some signals into the
existing `confidence` field calibrated against AMIE ground truth. These signals are left out in this PR
