### PR TITLE
ci(spark): rename the Spark test job to spark-test

### DIFF
--- a/.github/workflows/spark_tests.yml
+++ b/.github/workflows/spark_tests.yml
@@ -24,7 +24,9 @@ on:
       - '.github/workflows/spark_tests.yml'
 
 jobs:
-  build:
+  # Not "build": three other workflows already expose a check by that name, so
+  # the Spark run is indistinguishable in a PR's check list.
+  spark-test:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Four workflows exposed a check named `build` (`spark_tests.yml`, `run_tests.yaml` as `build (3.x)`, `github-packages-publish.yaml`, plus `docker`), so the Spark run was indistinguishable in a PR's check list — on #131 I briefly concluded the Spark suite had not triggered at all, when it was running under that generic name.

Renames the job key `build` -> `spark-test` in `spark_tests.yml`. No branch protection is configured on `develop`/`master`, so no required-status-check name breaks.

Self-verifying: the workflow triggers on changes to its own file, so this PR runs the Spark suite and the new check name shows up in its own check list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)