### PR TITLE
Detect 1inch swaps from transaction input

### DIFF
--- a/src/graphsenselib/db/asynchronous/services/models/__init__.py
+++ b/src/graphsenselib/db/asynchronous/services/models/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -220,7 +220,7 @@ class Parameter(BaseModel):
 class ParameterDetails(Parameter):
     name: str
     type: str
-    value: Union[str, int, float, bool]
+    value: Any
 
 
 class FunctionDefinition(BaseModel):
@@ -232,9 +232,7 @@ class FunctionDefinition(BaseModel):
 
 class FunctionCall(BaseModel):
     parameter_details: List[ParameterDetails]
-    parameter_values: Dict[str, Union[str, int, float, bool]] = Field(
-        default_factory=dict
-    )
+    parameter_values: Dict[str, Any] = Field(default_factory=dict)
     function_definition: FunctionDefinition
 
 

--- a/src/graphsenselib/defi/conversions.py
+++ b/src/graphsenselib/defi/conversions.py
@@ -185,9 +185,18 @@ async def get_conversions_from_db(
 
     from graphsenselib.defi.swaps import get_swap_from_decoded_logs
 
-    swap_results = get_swap_from_decoded_logs(
-        decoded_log_data, tx_logs_raw_filtered, tx_traces, visualize
-    )
+    if tx.get("input"):
+        swap_results = get_swap_from_decoded_logs(
+            decoded_log_data,
+            tx_logs_raw_filtered,
+            tx_traces,
+            visualize,
+            transaction_input=tx["input"],
+        )
+    else:
+        swap_results = get_swap_from_decoded_logs(
+            decoded_log_data, tx_logs_raw_filtered, tx_traces, visualize
+        )
     conversions += swap_results
 
     return conversions

--- a/src/graphsenselib/defi/swapping/models.py
+++ b/src/graphsenselib/defi/swapping/models.py
@@ -26,7 +26,9 @@ class ExternalSwap:
         return asdict(self)
 
 
-def get_swap_strategy_from_decoded_logs(dlogs: list) -> SwapStrategy:
+def get_swap_strategy_from_decoded_logs(
+    dlogs: list, parsed_input: dict | None = None
+) -> SwapStrategy:
     """Determine the swap detection strategy from decoded logs."""
     if not dlogs:
         return SwapStrategy.UNKNOWN
@@ -37,6 +39,7 @@ def get_swap_strategy_from_decoded_logs(dlogs: list) -> SwapStrategy:
         return dlog["log_def"]["tags"]
 
     tags = [tag for dlog in dlogs for tag in get_tags(dlog)]
+    parsed_input_tags = (parsed_input or {}).get("function_def", {}).get("tags", [])
     final_log_tags = dlogs[-1]["log_def"]["tags"] if dlogs else []
 
     # just a guess but i think it should be last, so its not just routed through there?
@@ -49,7 +52,7 @@ def get_swap_strategy_from_decoded_logs(dlogs: list) -> SwapStrategy:
         # e.g. https://etherscan.io/tx/0x8e7a3d044ed6873a5683ffe2f59b8cd68a3d786edaa64cdc4c05a9ae8ff97984
         # may settle multiple orders in one tx
         return SwapStrategy.IGNORE
-    elif "swap" in tags:
+    elif "swap" in tags or "swap" in parsed_input_tags:
         return SwapStrategy.SWAP
     else:
         return SwapStrategy.UNKNOWN

--- a/src/graphsenselib/defi/swaps.py
+++ b/src/graphsenselib/defi/swaps.py
@@ -23,6 +23,10 @@ from graphsenselib.defi.swapping.models import (
     get_swap_strategy_from_decoded_logs,
 )
 from graphsenselib.defi.models import Trace
+from graphsenselib.utils.function_call_parser import (
+    function_signatures,
+    parse_function_call,
+)
 
 
 @dataclass
@@ -547,6 +551,7 @@ def get_swap_from_decoded_logs(
     logs_raw: List[Dict[str, Any]],
     traces: List[Trace],
     visualize: bool = False,
+    transaction_input: Optional[bytes] = None,
 ) -> List[ExternalSwap]:
     """
     Main function to extract swap information from decoded logs.
@@ -561,7 +566,8 @@ def get_swap_from_decoded_logs(
     logs_raw = list(logs_raw_sorted)
 
     # Determine strategy
-    strategy = get_swap_strategy_from_decoded_logs(dlogs)
+    parsed_input = parse_function_call(transaction_input, function_signatures)
+    strategy = get_swap_strategy_from_decoded_logs(dlogs, parsed_input)
 
     # if strategy == SwapStrategy.IGNORE:
     swaps = []

--- a/src/graphsenselib/utils/function_call_parser.py
+++ b/src/graphsenselib/utils/function_call_parser.py
@@ -1,7 +1,21 @@
 import re
 from typing import Any, Dict, List, Optional
+
 from eth_abi import decode as abi_decode
-from eth_utils import to_hex, keccak
+from eth_utils import keccak, to_hex
+
+
+def _to_json_compatible(value: Any) -> Any:
+    """Convert ABI values to values that can safely cross the API boundary."""
+    if isinstance(value, (bytes, bytearray)):
+        return to_hex(value)
+    if isinstance(value, tuple):
+        return [_to_json_compatible(item) for item in value]
+    if isinstance(value, list):
+        return [_to_json_compatible(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _to_json_compatible(item) for key, item in value.items()}
+    return value
 
 
 def parse_function_call(
@@ -53,7 +67,11 @@ def parse_function_call(
                 inputs = []
                 for i, param in enumerate(func_def.get("inputs", [])):
                     param_name = param["name"]
-                    param_value = decoded_params[i] if i < len(decoded_params) else None
+                    param_value = (
+                        _to_json_compatible(decoded_params[i])
+                        if i < len(decoded_params)
+                        else None
+                    )
 
                     parameters[param_name] = param_value
                     inputs.append(
@@ -180,6 +198,20 @@ function_signatures = {
                 {"name": "deadline", "type": "uint256"},
             ],
             "tags": ["swap", "weth"],
+        }
+    ],
+    "0x07ed2379": [  # 1inch AggregationRouter swap(...)
+        {
+            "name": "swap",
+            "inputs": [
+                {"name": "executor", "type": "address"},
+                {
+                    "name": "desc",
+                    "type": "(address,address,address,address,uint256,uint256,uint256)",
+                },
+                {"name": "data", "type": "bytes"},
+            ],
+            "tags": ["swap", "1inch"],
         }
     ],
 }

--- a/tests/db/test_common.py
+++ b/tests/db/test_common.py
@@ -121,6 +121,31 @@ def test_function_call_from_row_with_empty_inputs():
     assert result.function_definition.arguments == []
 
 
+def test_function_call_from_row_supports_structured_abi_values():
+    parsed_input = {
+        "inputs": [
+            {"name": "desc", "type": "tuple", "value": ["0x1", 1]},
+            {"name": "data", "type": "bytes", "value": "0x1234"},
+        ],
+        "parameters": {"desc": ["0x1", 1], "data": "0x1234"},
+        "function_def": {
+            "name": "swap",
+            "inputs": [
+                {"name": "desc", "type": "tuple"},
+                {"name": "data", "type": "bytes"},
+            ],
+            "tags": ["swap", "1inch"],
+        },
+        "selector": "0x07ed2379",
+    }
+
+    result = function_call_from_row(parsed_input)
+
+    assert result.parameter_values == {"desc": ["0x1", 1], "data": "0x1234"}
+    assert result.parameter_details[0].value == ["0x1", 1]
+    assert result.parameter_details[1].value == "0x1234"
+
+
 def test_real_function_call_from_row():
     """
     This function is a placeholder for the actual implementation of function_call_from_row.

--- a/tests/defi/oneinch-swap-fixture.md
+++ b/tests/defi/oneinch-swap-fixture.md
@@ -1,0 +1,22 @@
+# 1inch swap regression fixture
+
+The regression tests use transaction
+`0x3e6538270a0b7dbb9bc00a80ee9c4ac5487b9a4dd94c73e753e45538219f0cf2` instead of the original transaction.
+
+It is a successful Ethereum mainnet transaction from
+`0xedcea136f0f7e5d51e1834bd96937847089fcdd4` to the same 1inch router,
+`0x111111125421ca6dc452d289314280a0f8842a65`. Its calldata uses selector
+`0x07ed2379`, the 1inch `swap` function that was missing from the function
+signature registry. The call swaps native ETH for GOOGLX
+(`0xe92f673ca36c5e2efd2de7628f815f84807e803f`).
+
+The receipt contains WETH `Deposit` and `Approval` events and token transfers,
+including the final GOOGLX transfer to the sender at log index 1864. This makes
+the fixture exercise call-level swap decoding and the resulting input/output
+payment flow with a different sender and a real token output.
+
+Sources:
+
+- [Transaction](https://eth.blockscout.com/api/v2/transactions/0x3e6538270a0b7dbb9bc00a80ee9c4ac5487b9a4dd94c73e753e45538219f0cf2)
+- [Transaction logs](https://eth.blockscout.com/api/v2/transactions/0x3e6538270a0b7dbb9bc00a80ee9c4ac5487b9a4dd94c73e753e45538219f0cf2/logs)
+- [Internal transactions](https://eth.blockscout.com/api/v2/transactions/0x3e6538270a0b7dbb9bc00a80ee9c4ac5487b9a4dd94c73e753e45538219f0cf2/internal-transactions?items_count=50)

--- a/tests/defi/test_swapping_models.py
+++ b/tests/defi/test_swapping_models.py
@@ -1,0 +1,29 @@
+from graphsenselib.defi.swapping.models import (
+    SwapStrategy,
+    get_swap_strategy_from_decoded_logs,
+)
+
+
+def test_1inch_swap_call_marks_logs_as_swap():
+    dlogs = [
+        {
+            "name": "Deposit",
+            "log_def": {"tags": ["weth", "wrap", "token"]},
+        }
+    ]
+    parsed_input = {
+        "function_def": {"tags": ["swap", "1inch"]},
+    }
+
+    assert get_swap_strategy_from_decoded_logs(dlogs, parsed_input) is SwapStrategy.SWAP
+
+
+def test_unknown_function_call_does_not_change_log_strategy():
+    dlogs = [
+        {
+            "name": "Deposit",
+            "log_def": {"tags": ["weth", "wrap", "token"]},
+        }
+    ]
+
+    assert get_swap_strategy_from_decoded_logs(dlogs) is SwapStrategy.UNKNOWN

--- a/tests/defi/test_swaps.py
+++ b/tests/defi/test_swaps.py
@@ -1,0 +1,123 @@
+from eth_abi import encode as abi_encode
+
+from graphsenselib.defi.models import Trace
+from graphsenselib.defi.swaps import get_swap_from_decoded_logs
+
+
+def test_1inch_eth_to_token_swap_is_detected_from_call_and_flows():
+    sender = "0xedcea136f0f7e5d51e1834bd96937847089fcdd4"
+    router = "0x111111125421ca6dc452d289314280a0f8842a65"
+    executor = "0x111116053f09d34a7eae8102887004445176ca11"
+    weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    token = "0xe92f673ca36c5e2efd2de7628f815f84807e803f"
+    amount = 2000000000000000
+    weth_amount = 1950000000000000
+    token_amount = 13848866016157488
+
+    dlogs = [
+        {
+            "name": "Deposit",
+            "address": weth,
+            "parameters": {"dst": executor, "wad": weth_amount},
+            "log_def": {"tags": ["weth", "wrap", "token"]},
+        },
+        {
+            "name": "Approval",
+            "address": weth,
+            "parameters": {"owner": executor, "spender": router, "value": weth_amount},
+            "log_def": {"tags": ["token", "erc20"]},
+        },
+        {
+            "name": "Transfer",
+            "address": token,
+            "parameters": {
+                "from": "0x67336cec42645f55059eff241cb02ea5cc52ff86",
+                "to": router,
+                "value": token_amount,
+            },
+            "log_def": {"tags": ["token", "erc20"]},
+        },
+        {
+            "name": "Transfer",
+            "address": weth,
+            "parameters": {
+                "from": executor,
+                "to": "0x67336cec42645f55059eff241cb02ea5cc52ff86",
+                "value": weth_amount,
+            },
+            "log_def": {"tags": ["token", "erc20"]},
+        },
+        {
+            "name": "Transfer",
+            "address": token,
+            "parameters": {"from": router, "to": sender, "value": token_amount},
+            "log_def": {"tags": ["token", "erc20"]},
+        },
+    ]
+    tx_hash = bytes.fromhex(
+        "3e6538270a0b7dbb9bc00a80ee9c4ac5487b9a4dd94c73e753e45538219f0cf2"
+    )
+    logs_raw = [
+        {"tx_hash": tx_hash, "log_index": log_index}
+        for log_index in (1858, 1859, 1860, 1862, 1864)
+    ]
+    traces = [
+        Trace(
+            from_address=sender,
+            to_address=router,
+            value=amount,
+            is_call=True,
+            trace_index=0,
+            trace_address="",
+        ),
+        Trace(
+            from_address=router,
+            to_address=executor,
+            value=amount,
+            is_call=True,
+            trace_index=1,
+            trace_address="1",
+        ),
+        Trace(
+            from_address=executor,
+            to_address=weth,
+            value=weth_amount,
+            is_call=True,
+            trace_index=2,
+            trace_address="9",
+        ),
+    ]
+    transaction_input = bytes.fromhex("07ed2379") + abi_encode(
+        [
+            "address",
+            "(address,address,address,address,uint256,uint256,uint256)",
+            "bytes",
+        ],
+        [
+            executor,
+            (
+                "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                token,
+                executor,
+                sender,
+                amount,
+                13431294583590000,
+                0,
+            ),
+            b"\x01",
+        ],
+    )
+
+    result = get_swap_from_decoded_logs(
+        dlogs, logs_raw, traces, transaction_input=transaction_input
+    )
+
+    assert len(result) == 1
+    assert result[0].fromAddress == sender
+    assert result[0].toAddress == sender
+    assert result[0].fromAsset == "native"
+    assert result[0].toAsset == token
+    assert result[0].fromAmount == amount
+    assert result[0].toAmount == token_amount
+    assert result[0].fromPayment.endswith("_I0")
+    assert result[0].toPayment.endswith("_T1864")

--- a/tests/utils/test_function_call_parser.py
+++ b/tests/utils/test_function_call_parser.py
@@ -1,11 +1,12 @@
+from eth_abi import encode as abi_encode
 from eth_utils import keccak, to_hex
 
 from graphsenselib.utils.function_call_parser import (
-    parse_function_call,
-    generate_function_selector,
     decoded_function_to_str,
-    get_filtered_function_signatures,
     function_signatures,
+    generate_function_selector,
+    get_filtered_function_signatures,
+    parse_function_call,
 )
 
 
@@ -84,6 +85,53 @@ def test_parse_function_call_approve_success():
     assert result["selector"] == "0x095ea7b3"
     assert len(result["inputs"]) == 2
     assert result["parameters"]["amount"] == 5000
+
+
+def test_parse_oneinch_swap_with_tuple_and_bytes():
+    """Decode the 1inch AggregationRouter swap used by the second fixture."""
+    executor = "0x111116053f09d34a7eae8102887004445176ca11"
+    src_token = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    dst_token = "0xe92f673ca36c5e2efd2de7628f815f84807e803f"
+    recipient = "0xedcea136f0f7e5d51e1834bd96937847089fcdd4"
+    amount = 2000000000000000
+
+    input_bytes = bytes.fromhex("07ed2379") + abi_encode(
+        [
+            "address",
+            "(address,address,address,address,uint256,uint256,uint256)",
+            "bytes",
+        ],
+        [
+            executor,
+            (
+                src_token,
+                dst_token,
+                executor,
+                recipient,
+                amount,
+                13431294583590000,
+                0,
+            ),
+            b"\x01",
+        ],
+    )
+
+    result = parse_function_call(input_bytes, function_signatures)
+
+    assert result is not None
+    assert result["name"] == "swap"
+    assert result["selector"] == "0x07ed2379"
+    assert result["parameters"]["executor"] == executor
+    assert result["parameters"]["desc"] == [
+        src_token,
+        dst_token,
+        executor,
+        recipient,
+        amount,
+        13431294583590000,
+        0,
+    ]
+    assert result["parameters"]["data"] == "0x01"
 
 
 def test_parse_function_call_no_parameters():


### PR DESCRIPTION
## Summary

Detect 1inch swaps when decoded logs do not contain a `swap` tag.

## Changes

- Add the 1inch AggregationRouter `swap` signature to the function-signature registry.
- Pass transaction input into swap detection when available.
- Use parsed function tags as a fallback when decoded logs do not identify a swap.
- Convert nested ABI values into JSON-compatible values.
- Update function-call models to accept structured ABI values.
- Add regression coverage for parsing, strategy selection, model serialization, and complete swap extraction.

## Validation

- `make pre-commit`
- `make test-ci`
- 2,331 tests passed, 1 skipped.
- Validate the change against a real Ethereum transaction in the Cassandra-backed backend.
- Confirm that the API returns `dex_swap` and the dashboard renders the transaction as a swap.