### PR TITLE
test: build the testcontainers on first use

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cache
 from os import environ
 from pathlib import Path
 import asyncio
@@ -64,9 +65,19 @@ cassandra_image = (
     FAST_CASSANDRA_IMAGE if DANGEROUSLY_ACCELERATE_TESTS else VANILLA_CASSANDRA_IMAGE
 )
 
-# Shared with web tests (imported by tests/web/conftest.py)
-cassandra = CassandraContainer(cassandra_image)
-postgres = PostgresContainer("postgres:16-alpine")
+
+# A container's constructor opens a Docker client, and pytest imports every
+# conftest before it collects, so building on first use is what lets a machine
+# without a daemon collect and run the tests that need none.
+@cache
+def cassandra_container() -> CassandraContainer:
+    return CassandraContainer(cassandra_image)
+
+
+@cache
+def postgres_container() -> PostgresContainer:
+    return PostgresContainer("postgres:16-alpine")
+
 
 # Test data directories for tagpack tests
 DATA_DIR_TP = Path(__file__).parent.resolve() / "testfiles" / "simple"
@@ -411,6 +422,7 @@ _cassandra_coords = ("localhost", "9042")
 def gs_db_setup():
     """Start Cassandra container. Only tests requesting this fixture pay the cost."""
     global _cassandra_coords
+    cassandra = cassandra_container()
     try:
         cassandra.start()
     except ImageNotFound as e:
@@ -437,6 +449,7 @@ def db_setup():
     if not TAGSTORE_AVAILABLE:
         pytest.skip("Tagstore dependencies not available")
 
+    postgres = postgres_container()
     postgres.start()
 
     postgres_sync_url = postgres.get_connection_url()

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cache
 from os import environ
 
 import pytest
@@ -26,6 +27,7 @@ class RedisContainer(DockerContainer):
     def get_exposed_port(self, port: int = REDIS_PORT) -> int:
         return int(super().get_exposed_port(port))
 
+
 from graphsenselib.web.app import create_app
 from graphsenselib.web.config import GSRestConfig
 from tests.web.cassandra.insert import load_test_data as cas_load_test_data
@@ -33,9 +35,16 @@ from tests.web.tagstore.insert import load_test_data as tags_load_test_data
 
 from tests.conftest import DANGEROUSLY_ACCELERATE_TESTS, create_web_schemas
 
-# Web-specific containers (not shared with root tests)
-postgres = PostgresContainer("postgres:16-alpine")
-redis = RedisContainer("redis:7-alpine")
+
+# Web-specific containers (not shared with root tests), built on first use.
+@cache
+def postgres_container() -> PostgresContainer:
+    return PostgresContainer("postgres:16-alpine")
+
+
+@cache
+def redis_container() -> RedisContainer:
+    return RedisContainer("redis:7-alpine")
 
 
 def _stop_container(container, name: str) -> None:
@@ -68,6 +77,8 @@ def gs_rest_db_setup(gs_db_setup):
 
     cas_host, cas_port = gs_db_setup
 
+    postgres = postgres_container()
+    redis = redis_container()
     postgres.start()
     redis.start()
 
@@ -145,6 +156,7 @@ async def redis_client(gs_rest_db_setup):
     """Provide an async Redis client for tests."""
     from redis import asyncio as aioredis
 
+    redis = redis_container()
     redis_host = redis.get_container_host_ip()
     redis_port = redis.get_exposed_port(6379)
     redis_url = f"redis://{redis_host}:{redis_port}"


### PR DESCRIPTION
`pytest tests/utils --collect-only` exits 4 on a machine with no Docker daemon:

```
tests/conftest.py:68: in <module>
    cassandra = CassandraContainer(cassandra_image)
E   docker.errors.DockerException: Error while fetching server API version:
    ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))
```

A container's constructor opens a `DockerClient`, and pytest imports every conftest before it collects, so the four module-level containers make a daemon a precondition of collecting anything at all. `gs_db_setup` already says otherwise: "Only tests requesting this fixture pay the cost."

`functools.cache` on a constructor function keeps the one instance per session that the module-level names gave, and moves the Docker call to the first fixture that asks for it.

Same worktree and same venv, only the commit differing: on `develop` nothing is collected, on this branch 205 are and 201 pass. The four failures are `tests/utils/test_pipeline.py` under `spawn`, unrelated to containers and older than this branch. I can open an issue for them if useful, along with the fact that nothing under `src/` imports `utils/pipeline.py`.

`uv run ruff check tests src` is clean. `ruff format` also took one blank line in `tests/web/conftest.py` that `--check` fails on `develop` too.
